### PR TITLE
GitHubActions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build
         run: |
           npm run build
-          mkdir PR
+          mkdir PR &>/dev/null
           mv public/ PR/${{ github.sha }}/
 
       - name: Git checkout


### PR DESCRIPTION
- PRディレクトリがすでに存在していた場合のエラー出力を捨てる